### PR TITLE
Add missing translations

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -656,7 +656,7 @@ translations:
     - key: options.tool_evaluation.creator_team
       t: Creator & Team
     - key: options.tool_evaluation.creator_team.description
-      t: Wird es von einem bekannten, erfahrenen und gut ausgestatteten Tam entwickelt?
+      t: Wird es von einem bekannten, erfahrenen und gut ausgestatteten Team entwickelt?
     - key: options.tool_evaluation.accessibility_features
       t: Accessibility Features
     - key: options.tool_evaluation.accessibility_features.description

--- a/common.yml
+++ b/common.yml
@@ -688,6 +688,24 @@ translations:
     - key: options.accessibility_features.aria_attributes
       t: ARIA HTML Attribute
 
+    # css usage
+    - key: options.what_do_you_use_css_for.marketing_sites
+      t: Marketingseiten & Landingpages
+    - key: options.what_do_you_use_css_for.design_systems
+      t: Design Systems
+    - key: options.what_do_you_use_css_for.blogs
+      t: Blogs oder andere textlastige Webseiten
+    - key: options.what_do_you_use_css_for.web_apps
+      t: Webapps
+    - key: options.what_do_you_use_css_for.mobile_apps
+      t: Mobile Apps
+    - key: options.what_do_you_use_css_for.css_art
+      t: CSS-Kunst & Illustrationen
+    - key: options.what_do_you_use_css_for.emails
+      t: Emails
+    - key: options.what_do_you_use_css_for.printed_documents
+      t: Gedruckte Dokumente
+
     ###########################################################################
     # Tools
     ###########################################################################

--- a/common.yml
+++ b/common.yml
@@ -431,6 +431,13 @@ translations:
     - key: options.yearly_salary.range_more_than_200.short
       t: '>$200k'
 
+    # higher education degree
+    - key: options.higher_education_degree.no
+      t: Nein
+    - key: options.higher_education_degree.yes_related
+      t: Ja, in einem Bereich, der mit meinem derzeitigen Beruf zusammenhängt
+    - key: options.higher_education_degree.yes_unrelated
+      t: Ja, aber in einem Bereich, der nichts mit meinem derzeitigen Beruf zu tun hat
     # job titles
     - key: options.job_title.cto
       t: CTO
@@ -746,6 +753,12 @@ translations:
       t: Jährliches Einkommen
     - key: user_info.yearly_salary.description
       t: Jährliches Einkommen in USD.
+
+    # higher education degree
+    - key: user_info.higher_education_degree
+      t: Hochschulabschluss?
+    - key: user_info.higher_education_degree.description
+      t: Besitzt Du einen Hochschulabschluss?
 
     # job title
     - key: user_info.job_title

--- a/common.yml
+++ b/common.yml
@@ -890,6 +890,37 @@ translations:
     # Resources
     ###########################################################################
 
+    # first steps
+    - key: resources.first_steps
+      t: Erste Schritte mit CSS
+    - key: resources.first_steps.description
+      t: Wie hast Du zu Beginn deiner Tätigkeit CSS gelernt?
+    - key: resources.first_steps.books
+      t: Bücher
+    - key: resources.first_steps.videos
+      t: Videos & Screencasts
+    - key: resources.first_steps.courses_free
+      t: Onlinekurse (kostenlos)
+    - key: resources.first_steps.courses_paid
+      t: Onlinekurse (bezahlt)
+    - key: resources.first_steps.school
+      t: Schule & höhere Bildung
+    - key: resources.first_steps.podcasts
+      t: Podcasts
+    - key: resources.first_steps.bootcamp
+      t: Bootcamps
+    - key: resources.first_steps.on_the_job
+      t: Ausbildung am Arbeitsplatz
+    - key: resources.first_steps.mentoring
+      t: Mentoring
+    - key: resources.first_steps.self_directed
+      t: Selbstgesteuertes Lernen (Google, Stack Overflow, usw.)
+    - key: resources.first_steps.others
+      t: Andere erste Lernmethoden
+    - key: resources.first_steps.others.description
+      t: Andere Antworten (Freifeld).
+
+
     # blogs & magazines
     - key: resources.blogs_news_magazines
       t: Blogs & Magazine

--- a/common.yml
+++ b/common.yml
@@ -695,24 +695,6 @@ translations:
     - key: options.accessibility_features.aria_attributes
       t: ARIA HTML Attribute
 
-    # css usage
-    - key: options.what_do_you_use_css_for.marketing_sites
-      t: Marketingseiten & Landingpages
-    - key: options.what_do_you_use_css_for.design_systems
-      t: Design Systems
-    - key: options.what_do_you_use_css_for.blogs
-      t: Blogs oder andere textlastige Webseiten
-    - key: options.what_do_you_use_css_for.web_apps
-      t: Webapps
-    - key: options.what_do_you_use_css_for.mobile_apps
-      t: Mobile Apps
-    - key: options.what_do_you_use_css_for.css_art
-      t: CSS-Kunst & Illustrationen
-    - key: options.what_do_you_use_css_for.emails
-      t: Emails
-    - key: options.what_do_you_use_css_for.printed_documents
-      t: Gedruckte Dokumente
-
     ###########################################################################
     # Tools
     ###########################################################################
@@ -902,37 +884,6 @@ translations:
     ###########################################################################
     # Resources
     ###########################################################################
-
-    # first steps
-    - key: resources.first_steps
-      t: Erste Schritte mit CSS
-    - key: resources.first_steps.description
-      t: Wie hast Du zu Beginn deiner Tätigkeit CSS gelernt?
-    - key: resources.first_steps.books
-      t: Bücher
-    - key: resources.first_steps.videos
-      t: Videos & Screencasts
-    - key: resources.first_steps.courses_free
-      t: Onlinekurse (kostenlos)
-    - key: resources.first_steps.courses_paid
-      t: Onlinekurse (bezahlt)
-    - key: resources.first_steps.school
-      t: Schule & höhere Bildung
-    - key: resources.first_steps.podcasts
-      t: Podcasts
-    - key: resources.first_steps.bootcamp
-      t: Bootcamps
-    - key: resources.first_steps.on_the_job
-      t: Ausbildung am Arbeitsplatz
-    - key: resources.first_steps.mentoring
-      t: Mentoring
-    - key: resources.first_steps.self_directed
-      t: Selbstgesteuertes Lernen (Google, Stack Overflow, usw.)
-    - key: resources.first_steps.others
-      t: Andere erste Lernmethoden
-    - key: resources.first_steps.others.description
-      t: Andere Antworten (Freifeld).
-
 
     # blogs & magazines
     - key: resources.blogs_news_magazines

--- a/state_of_css.yml
+++ b/state_of_css.yml
@@ -609,6 +609,8 @@ translations:
       t: Andere Barrierefreiheitsfunktionen
     - key: environments.accessibility_features.others
       t: Andere Barrierefreiheitsfunktionen, die du normalerweise implementierst.
+    - key: environments.what_do_you_use_css_for.others
+      t: Andere Projektarten
     - key: environments.css_for_print
       t: CSS für Print
     - key: environments.css_for_print.description

--- a/state_of_css.yml
+++ b/state_of_css.yml
@@ -1,706 +1,758 @@
 locale: de-DE
 namespace: css
 translations:
-    ###########################################################################
-    # General
-    ###########################################################################
+  ###########################################################################
+  # General
+  ###########################################################################
 
-    - key: general.survey_intro_css2020
-      t: >
-          CSS entwickelt sich schneller als je zuvor.
+  - key: general.survey_intro_css2020
+    t: >
+      CSS entwickelt sich schneller als je zuvor.
 
-          Flexbox, Grid, Multi-Column... Und dabei sind wir noch gar nicht bei den neuen Paradigmen wie CSS-in-JS.
+      Flexbox, Grid, Multi-Column... Und dabei sind wir noch gar nicht bei den neuen Paradigmen wie CSS-in-JS.
 
-          Auf Grund des Erfolgs unserer jährlichen State Of JavaScript Umfragen haben wir entschieden einen Schritt in die Welt der Styles und Selektoren zu gehen. Wir hoffen Du hilfst uns die aktuellen Trends zu identifizieren und herauszufinden welche Tools es sich lohnt als nächstes zu lernen und zu nutzen!
+      Auf Grund des Erfolgs unserer jährlichen State Of JavaScript Umfragen haben wir entschieden einen Schritt in die Welt der Styles und Selektoren zu gehen. Wir hoffen Du hilfst uns die aktuellen Trends zu identifizieren und herauszufinden welche Tools es sich lohnt als nächstes zu lernen und zu nutzen!
 
 
 
 
 
-    - key: general.results.description
-      t: Die jährliche Umfrage zu den CSS-Trends.
+  - key: general.results.description
+    t: Die jährliche Umfrage zu den CSS-Trends.
 
-    ###########################################################################
-    # Sections
-    ###########################################################################
+  ###########################################################################
+  # Sections
+  ###########################################################################
 
-    - key: sections.layout.title
-      t: Layout
-    - key: sections.layout.description
-      t: Wie positionierst Du Elemente auf dem Bildschirm?
+  - key: sections.layout.title
+    t: Layout
+  - key: sections.layout.description
+    t: Wie positionierst Du Elemente auf dem Bildschirm?
 
-    - key: sections.shapes_graphics.title
-      t: Formen und Grafik
-    - key: sections.shapes_graphics.description
-      t: Kontrolliere die Form und Anzeige von Elementen.
+  - key: sections.shapes_graphics.title
+    t: Formen und Grafik
+  - key: sections.shapes_graphics.description
+    t: Kontrolliere die Form und Anzeige von Elementen.
 
-    - key: sections.interactions.title
-      t: Interaktionen
-    - key: sections.interactions.description
-      t: Kontrolliere wie der Nutzer mit der Seite interagiert.
-
-    - key: sections.typography.title
-      t: Typographie
-    - key: sections.typography.description
-      t: Einstellungen und Layout von Text.
-
-    - key: sections.animations_transforms.title
-      t: Animationen & Transformationen
-    - key: sections.animations_transforms.description
-      t: Animiere und transformiere Elemente.
-
-    - key: sections.accessibility.title
-      t: Accessibility
-    - key: sections.accessibility.description
-      t: Accessibility Features und Techniken.
-
-    - key: sections.media_queries.title
-      t: Media Queries
-    - key: sections.media_queries.description
-      t: Möglichkeiten die Seite an Geräte und Präferenzen von Nutzern anzupassen.
-
-    - key: sections.other_features.title
-      t: Andere Features
-    - key: sections.other_features.description
-      t: Andere CSS-Features.
-
-    - key: sections.units_selectors.title
-      t: Einheiten und Selektoren
-    - key: sections.units_selectors.description
-      t: Teste Dein Wissen zu CSS Einheiten und Selektoren.
-
-    - key: sections.pre_post_processors.title
-      t: Pre-/Post-processors
-    - key: sections.pre_post_processors.description
-      t: Werkzeuge, die CSS erweitern.
-
-    - key: sections.pre_post_processors_others.title
-      t: Andere Pre-/Post-Prozessoren
-
-    - key: sections.css_frameworks.title
-      t: CSS Frameworks
-    - key: sections.css_frameworks.description
-      t: Bibliotheken, die Dir vordefinierte Komponenten und Styles liefern.
-
-    - key: sections.css_frameworks_others.title
-      t: Andere CSS-Frameworks
-
-    - key: sections.css_methodologies.title
-      t: CSS Methoden
-    - key: sections.css_methodologies.description
-      t: Kodifizierte Optionen wie sauberes CSS geschrieben wird.
-
-    - key: sections.css_methodologies_others.title
-      t: Andere CSS-Methoden
-
-    - key: sections.css_in_js.title
-      t: CSS-in-JS
-    - key: sections.css_in_js.description
-      t: Bibliotheken, die bei der Integration von CSS nach JavaScript helfen.
-
-    - key: sections.css_in_js_others.title
-      t: Andere CSS-in-JS Bibliotheken
-
-    - key: sections.tools_others.title
-      t: Andere Werkzeuge
-    - key: sections.tools_others.description
-      t: Andere CSS-Werkzeuge
-
-    - key: sections.environments.title
-      t: Umgebungen
-    - key: sections.environments.description
-      t: Für welche Umgebungen schreibst Du CSS?
-
-    ###########################################################################
-    # Options
-    ###########################################################################
-
-    # CSS for print
-    - key: options.css_for_print.0
-      t: Ich schreibe fast nie Print Styles.
-    - key: options.css_for_print.0.short # TODO
-      t: Nie
-
-    - key: options.css_for_print.1
-      t: Ich schreibe gelegentlich Print Styles.
-    - key: options.css_for_print.1.short # TODO
-      t: Gelegentlich
-
-    - key: options.css_for_print.2
-      t: Ich schreibe Print Styles üblicherweise als Teil meiner Projekte.
-    - key: options.css_for_print.2.short # TODO
-      t: Oft
-
-    - key: options.css_for_print.3
-      t: Ich schreibe hauptsächlich Print Styles.
-    - key: options.css_for_print.3.short # TODO
-      t: Hauptsächlich
-
-    # CSS for email
-    - key: options.css_for_email.0
-      t: Ich schreibe fast nie CSS für E-Mail Clients.
-    - key: options.css_for_email.0.short # TODO
-      t: Nie
-
-    - key: options.css_for_email.1
-      t: Ich schreibe gelegentlich CSS für E-Mail Clients.
-    - key: options.css_for_email.1.short # TODO
-      t: Gelegentlich
-
-    - key: options.css_for_email.2
-      t: Ich schreibe CSS für E-Mail Clients üblicherweise als Teil meiner Projekte.
-    - key: options.css_for_email.2.short # TODO
-      t: Oft
-
-    - key: options.css_for_email.3
-      t: Ich schreibe CSS hauptsächlich für E-Mail Clients.
-    - key: options.css_for_email.3.short # TODO
-      t: Hauptsächlich
-
-    # CSS pain points
-    - key: options.css_pain_points.browser_interoperability
-      t: Browser Kompatibilität
-    - key: options.css_pain_points.browser_interoperability.description
-      t: Unterschiede zwischen Chrome, Safari, Firefox usw.
-    - key: options.css_pain_points.interactions
-      t: Interaktionen
-    - key: options.css_pain_points.interactions.description
-      t: Antwort auf Nutzereingaben und andere Events (scrollen, hover usw.).
-    - key: options.css_pain_points.architecture
-      t: Architektur & Wartbarkeit
-    - key: options.css_pain_points.architecture.description
-      t: Dateimanagement, Dead Code Eliminierung, Refactoring usw.
-    - key: options.css_pain_points.layout_positioning
-      t: Layout & Positionierung
-    - key: options.css_pain_points.layout_positioning.description
-      t: Entwerfen von Layouts und sicherstellen, dass Elemente am gewünschten Platz sind.
-    - key: options.css_pain_points.scoping_specificity
-      t: Bereiche & Spezifität
-    - key: options.css_pain_points.scoping_specificity.description
-      t: Die Kaskade und das Überschreiben von Stilen usw.
-    - key: options.css_pain_points.responsive_design
-      t: Responsive Design
-    - key: options.css_pain_points.responsive_design.description
-      t: Adaptieren von Layouts und Gestaltungen für verschiedene Geräte.
-    - key: options.css_pain_points.form_elements_styling
-      t: Stile für Formularelemente
-    - key: options.css_pain_points.form_elements_styling.description
-      t: Anpassung des Aussehens und des Verhaltens von Formularen.
-    - key: options.css_pain_points.performance_issues
-      t: Performance Probleme
-    - key: options.css_pain_points.performance_issues.description
-      t: Umgang mit Scrolling, Animationen flüssiger machen usw.
-
-    ###########################################################################
-    # Features
-    ###########################################################################
-
-    # layout
-
-    - key: features.grid
-      t: CSS Grid
-    - key: features.subgrid
-      t: Subgrid
-    - key: features.regions
-      t: CSS Regions
-    - key: features.flexbox
-      t: Flexbox
-    - key: features.multi_column
-      t: CSS Multi-Column
-    - key: features.writing_modes
-      t: CSS Writing Modes
-    - key: features.exclusions
-      t: CSS Exclusions
-    - key: features.position_sticky
-      t: '<code>position: sticky</code>'
-    - key: features.logical_properties
-      t: Logical Properties
-    - key: features.logical_properties.description
-      t: <code>margin-block-start</code>, <code>padding-inline-end</code> usw.
-    - key: features.aspect_ratio
-      t: <code>aspect-ratio</code>
-    - key: features.content_visibility
-      t: <code>content-visibility</code>
-    - key: features.flexbox_gap
-      t: Gap Property für flexbox
-    - key: features.break_rules
-      t: Break rules
-    - key: features.break_rules.description
-      t: <code>break-inside</code>, <code>break-before</code>, <code>break-after</code>
-    - key: features.at_container
-      t: Container Queries
-    - key: features.at_container.description
-      t: <code>@container</code> query
-
-    # shapes & graphics
-    - key: features.shapes
-      t: CSS Shapes
-    - key: features.object_fit
-      t: <code>object-fit</code>
-    - key: features.clip_path
-      t: <code>clip-path</code>
-    - key: features.masks
-      t: CSS Masks
-    - key: features.blend_modes
-      t: Blend Modes
-    - key: features.blend_modes.description
-      t: Die <code>mix-blend-mode</code> Eigenschaft
-    - key: features.filter_effects
-      t: CSS Filter Effects
-    - key: features.backdrop_filter
-      t: <code>backdrop-filter</code>
-
-    - key: features.intrinsic_sizing
-      t: Intrinsic Sizing
-    - key: features.intrinsic_sizing.description
-      t: <code>min-content</code>, <code>max-content</code>, <code>fit-content</code>
-    - key: features.repeating_linear_gradient
-      t: <code>repeating-linear-gradient()</code>
-    - key: features.conic_gradient
-      t: <code>conic-gradient()</code>
-    - key: features.color_function
-      t: <code>color()</code>
-
-    - key: features.accent_color
-      t: <code>accent-color</code>
-
-    # interactions
-    - key: features.scroll_snap
-      t: CSS Scroll Snap
-    - key: features.overscroll_behavior
-      t: <code>overscroll-behavior</code>
-    - key: features.overflow_anchor
-      t: <code>overflow-anchor</code>
-    - key: features.touch_action
-      t: <code>touch-action</code>
-    - key: features.pointer_events
-      t: <code>pointer-events</code>
-    - key: features.scroll_timeline
-      t: <code>scroll-timeline</code>
-
-    # typography
-    - key: features.web_fonts
-      t: Web Fonts (@font-face)
-    - key: features.variables_fonts
-      t: Variable Fonts
-    - key: features.line_breaking
-      t: Line breaking Properties
-    - key: features.line_breaking.description
-      t: <code>overflow-wrap</code>, <code>word-break</code>, <code>line-break</code>, <code>hyphens</code>
-    - key: features.font_variant
-      t: <code>font-variant-*</code>
-    - key: features.initial_letter
-      t: <code>initial-letter</code>
-    - key: features.font_variant_numeric
-      t: <code>font-variant-numeric</code>
-    - key: features.font_display
-      t: <code>font-display</code>
-    - key: features.line_clamp
-      t: <code>line-clamp</code>
-    - key: features.leading_trim
-      t: <code>leading-trim</code>
-    - key: features.direction
-      t: <code>direction</code>
-    - key: features.direction.description
-      t: Beinhaltet auch <code>dir</code>-HTML-Attribute.
-
-    # animations & transforms
-    - key: features.transitions
-      t: CSS Transitions
-    - key: features.transforms
-      t: CSS Transforms
-    - key: features.animations
-      t: CSS Animations
-    - key: features.perspective
-      t: <code>perspective</code>
-
-    # media queries/accessibility
-    - key: features.feature_support_queries
-      t: Feature Support Queries (<code>@supports</code>)
-    - key: features.prefers_reduced_motion
-      t: <code>prefers-reduced-motion</code>
-    - key: features.prefers_color_scheme
-      t: <code>prefers-color-scheme</code>
-    - key: features.color_gamut
-      t: <code>color-gamut</code>
-
-    - key: features.prefers_reduced_data
-      t: <code>prefers-reduced-data</code>
-    - key: features.tabindex
-      t: <code>tabindex</code>-HTML-Attribute
-    - key: features.tabindex.description
-      t: <code>&lt;div tabindex="0"&gt;</code>
-
-    - key: features.color_contrast
-      t: <code>color-contrast()</code>
-
-    - key: features.color_scheme
-      t: <code>color-scheme</code>
-
-    - key: features.aria_attributes
-      t: ARIA-HTML-Attribute
-    - key: features.aria_attributes.description
-      t: <code>&lt;role&gt;</code>, <code>&lt;aria-label&gt;</code>, etc.
-
-    # other features
-    - key: features.variables
-      t: CSS Variables (Custom Properties)
-    - key: features.containment
-      t: CSS Containment
-    - key: features.will_change
-      t: <code>will-change</code>
-    - key: features.calc
-      t: <code>calc()</code>
-    - key: features.houdini
-      t: Houdini
-    - key: features.comparison_functions
-      t: CSS Comparison Functions
-    - key: features.comparison_functions.description
-      t: <code>min()</code>, <code>max()</code> und <code>clamp()</code>
-
-    - key: features.at_property
-      t: Houdini Custom Properties
-    - key: features.at_property.description
-      t: <code>@property</code>
-    - key: features.at_layer
-      t: <code>@layer</code>
-    - key: features.content_visibility
-      t: <code>content-visibility</code>
-    - key: features.marker
-      t: <code>::marker</code> pseudo-element
-
-    # missing features
-    - key: features.nesting
-      t: Verschachtelung
-    - key: features.nesting.description
-      t: Die Möglichkeit, Stile in nativem CSS zu verschachteln.
-    - key: features.parent_selector
-      t: Parent Selector
-    - key: features.parent_selector.description
-      t: Die Möglichkeit, auf ein übergeordnetes Element basierend auf seinen untergeordneten Elementen abzuzielen.
-    - key: features.browser_support
-      t: Browser Support
-    - key: features.browser_support.description
-      t: Bessere Browser-Unterstützung für existierende Features.
-    - key: features.mixins
-      t: Mixins
-    - key: features.mixins.description
-      t: Definitionen dynamisch gruppieren und wiederverwenden.
-    - key: features.color_functions
-      t: Color Functions
-    - key: features.color_functions.description
-      t: Funktionen zum Manipulieren von Farbwerten.
-    - key: features.container_queries
-      t: Container Queries
-    - key: features.container_queries.description
-      t: In der Lage sein, Stile basierend auf den Dimensionen des übergeordneten Containers zu schreiben.
-    - key: features.scoping
-      t: Scoping
-    - key: features.scoping.description
-      t: Die Möglichkeit, genauer anzugeben, wo die Stile angewendet werden.
-    - key: features.subgrid
-      t: Subgrid
-    - key: features.subgrid.description
-      t: Verschachtelung von Subgrids auf tieferen Ebenen in einem übergeordneten Raster.
-
-    ###########################################################################
-    # Units & Selectors
-    ###########################################################################
-
-    - key: features_others.units
-      t: Einheiten
-    - key: features_others.units.description
-      t: Welche dieser CSS Einheiten hast Du genutzt?
-
-    - key: options.units.px
-      t: px
-    - key: options.units.pt
-      t: pt
-    - key: options.units.percent
-      t: '%'
-    - key: options.units.em
-      t: em
-    - key: options.units.rem
-      t: rem
-    - key: options.units.vh_vw
-      t: vh, vw
-    - key: options.units.vmin_vmax
-      t: vmin, vmax
-    - key: options.units.ch
-      t: ch
-    - key: options.units.ex
-      t: ex
-    - key: options.units.mm
-      t: mm
-    - key: options.units.cm
-      t: cm
-    - key: options.units.in
-      t: in
-
-    - key: features_others.pseudo_elements
-      t: Pseudoelemente
-    - key: features_others.pseudo_elements.description
-      t: Welche dieser CSS Pseudoelemente hast Du genutzt?
-
-    - key: options.pseudo_elements.before
-      t: '::before'
-    - key: options.pseudo_elements.after
-      t: '::after'
-    - key: options.pseudo_elements.first_line
-      t: '::first-line'
-    - key: options.pseudo_elements.first_letter
-      t: '::first-letter'
-    - key: options.pseudo_elements.selection
-      t: '::selection'
-    - key: options.pseudo_elements.placeholder
-      t: '::placeholder'
-    - key: options.pseudo_elements.marker
-      t: '::marker'
-    - key: options.pseudo_elements.backdrop
-      t: '::backdrop'
-
-    - key: features_others.combinators
-      t: Verkettungen
-    - key: features_others.combinators.description # TODO
-      t: Welche dieser kombinierten CSS-Selektoren hast du verwendet?
-
-    - key: options.combinators.descendant
-      t: div span (absteigend)
-    - key: options.combinators.child
-      t: div > span (Kind)
-    - key: options.combinators.next_sibling
-      t: div + div (nächste Geschwister)
-    - key: options.combinators.subsequent_sibling
-      t: div ~ div (nachfolgende Geschwister)
-
-    - key: features_others.tree_document_structure
-      t: Baum/ Dokumentstruktur
-    - key: features_others.tree_document_structure.description # TODO
-      t: Welche dieser strukturbezogenen CSS-Selektoren hast du verwendet?
-
-    - key: options.tree_document_structure.root
-      t: :root
-    - key: options.tree_document_structure.empty
-      t: :empty
-    - key: options.tree_document_structure.not
-      t: :not()
-    - key: options.tree_document_structure.nth_child
-      t: :nth-child()
-    - key: options.tree_document_structure.nth_last_child
-      t: :nth-last-child()
-    - key: options.tree_document_structure.first_child
-      t: :first-child
-    - key: options.tree_document_structure.last_child
-      t: :last-child
-    - key: options.tree_document_structure.only_child
-      t: :only-child
-    - key: options.tree_document_structure.nth_of_type
-      t: :nth-of-type()
-    - key: options.tree_document_structure.nth_last_of_type
-      t: :nth-last-of-type()
-    - key: options.tree_document_structure.first_of_type
-      t: :first-of-type
-    - key: options.tree_document_structure.last_of_type
-      t: :last-of-type
-    - key: options.tree_document_structure.only_of_type
-      t: :only-of-type
-    - key: options.tree_document_structure.lang
-      t: :lang()
-    - key: options.tree_document_structure.is
-      t: :is()
-    - key: options.tree_document_structure.where
-      t: :where()
-    - key: options.tree_document_structure.has
-      t: :has()
-
-    - key: features_others.attributes
-      t: Attribute
-    - key: features_others.attributes.description # TODO
-      t: Welche dieser CSS-Attributselektoren hast du verwendet?
-
-    - key: options.attributes.presence
-      t: div[foo] (Vorhandensein)
-    - key: options.attributes.equality
-      t: div[foo="bar"] (Gleichwertigkeit)
-    - key: options.attributes.starts_with
-      t: div[foo^="bar"] (Beginnt mit)
-    - key: options.attributes.ends_with
-      t: div[foo$="bar"] (Endet mit)
-    - key: options.attributes.contains_word
-      t: div[foo~="bar"] (Beinhaltet Wort)
-    - key: options.attributes.contains_substring
-      t: div[foo*="bar"] (Beinhaltet Zeichen)
-
-    - key: features_others.links_urls
-      t: Links/URLs
-    - key: features_others.links_urls.description # TODO
-      t: Welche dieser Link- und URL-bezogenen CSS-Selektoren hast du verwendet?
-
-    - key: options.links_urls.any_link
-      t: :any-link
-    - key: options.links_urls.link_visited
-      t: :link und :visited
-    - key: options.links_urls.local_link
-      t: :local-link
-    - key: options.links_urls.target
-      t: :target
-
-    - key: features_others.interaction
-      t: Interaktion
-    - key: features_others.interaction.description # TODO
-      t: Welche dieser CSS-Selektoren für Interaktionen hast du verwendet?
-
-    - key: options.interaction.hover
-      t: :hover
-    - key: options.interaction.active
-      t: :active
-    - key: options.interaction.focus
-      t: :focus
-    - key: options.interaction.focus_within
-      t: :focus-within
-    - key: options.interaction.focus_visible
-      t: :focus-visible
-
-    - key: features_others.form_controls
-      t: Formularfelder
-    - key: features_others.form_controls.description # TODO
-      t: Welche dieser formularbezogenen CSS-Selektoren hast du verwendet?
-
-    - key: options.form_controls.enabled_disabled
-      t: :enabled und :disabled
-    - key: options.form_controls.read_only_write
-      t: :read-only und :read-write
-    - key: options.form_controls.placeholder_shown
-      t: :placeholder-shown
-    - key: options.form_controls.default
-      t: :default
-    - key: options.form_controls.checked
-      t: :checked
-    - key: options.form_controls.indeterminate
-      t: :indeterminate
-    - key: options.form_controls.valid_invalid
-      t: :valid und :invalid
-    - key: options.form_controls.user_invalid
-      t: :user-invalid
-    - key: options.form_controls.in_out_range
-      t: :in-range und :out-of-range
-    - key: options.form_controls.required_optional
-      t: :required und :optional
-
-    ###########################################################################
-    # Environments
-    ###########################################################################
-
-    - key: environments.browsers
-      t: Browser
-    - key: environments.browsers.description
-      t: Welchen Browser nutzt du zum Testen?
-
-    - key: environments.form_factors
-      t: Formfaktoren
-    - key: environments.form_factors.description
-      t: Mit welchen Formfaktoren testest du?
-
-    - key: environments.accessibility_features
-      t: Barrierefreiheitsfunktionen
-    - key: environments.accessibility_features.description
-      t: Welche Barrierefreiheitsfunktionen implementierst du normalerweise?
-    - key: environments.accessibility_features.others
-      t: Andere Barrierefreiheitsfunktionen
-    - key: environments.accessibility_features.others
-      t: Andere Barrierefreiheitsfunktionen, die du normalerweise implementierst.
-    - key: environments.what_do_you_use_css_for.others
-      t: Andere Projektarten
-    - key: environments.css_for_print
-      t: CSS für Print
-    - key: environments.css_for_print.description
-      t: Schreibst du Styles für Print?
-
-    - key: environments.css_for_email
-      t: CSS für E-Mail Clients
-    - key: environments.css_for_email.description
-      t: Schreibst Du CSS für E-Mail Clients?
-
-    - key: charts.axis_legends.css_for_print
-      t: Frequenz
-    - key: charts.axis_legends.css_for_email
-      t: Frequenz
-
-    - key: tools_others.tool_evaluation
-      t: Bibliotheksbewertung
-    - key: tools_others.tool_evaluation.description
-      t: Wähle für jede Übereinstimmung den Faktor aus, den du bei der Bewertung einer neuen Bibliothek priorisierst.
-
-    ###########################################################################
-    # Opinions
-    ###########################################################################
-
-    - key: opinions.css_easy_to_learn
-      t: CSS ist leicht zu lernen.
-    - key: opinions.css_easy_to_learn.title # TODO
-      t: Lernkurve
-
-    - key: opinions.css_evolving_slowly
-      t: CSS entwickelt sich zu langsam.
-    - key: opinions.css_evolving_slowly.title # TODO
-      t: Veränderungsrate
-
-    - key: opinions.utility_classes_to_be_avoided
-      t: Werkzeugklassen (nicht-semantische z.B. .center, .large-text, usw.) sollten vermieden werden.
-    - key: opinions.utility_classes_to_be_avoided.title # TODO
-      t: Non-Semantic Classes
-
-    - key: opinions.selector_nesting_to_be_avoided
-      t: Verschachteln von Selektoren (.foo .bar ul li {...}) sollte vermieden werden.
-    - key: opinions.selector_nesting_to_be_avoided.title # TODO
-      t: Selector Verschachtelung
-
-    - key: opinions.css_is_programming_language
-      t: CSS ist eine Programmiersprache.
-    - key: opinions.css_is_programming_language.title # TODO
-      t: Programmiersprache
-
-    - key: opinions.enjoy_writing_css
-      t: Ich genieße es CSS zu schreiben.
-    - key: opinions.enjoy_writing_css.title # TODO
-      t: Freude
-
-    # Browser interoperability question
-    - key: opinions.browser_interoperability_features
-      t: Browser-Inkompatibilitäten
-    - key: opinions.browser_interoperability_features.description
-      t: >
-        Gibt es CSS-Funktionen, die du aufgrund von Unterschieden
-        zwischen den Browsern nicht verwenden kannst?
-
-    # Pain Points
-    - key: opinions.css_pain_points
-      t: CSS Pain Points
-    - key: opinions.css_pain_points.description
-      t: Wähle für jede Übereinstimmung den Aspekt von CSS aus, mit dem du am meisten zu kämpfen hast.
-
-    - key: opinions_other.css_pain_points.others
-      t: Andere CSS Pain Points
-
-    # Missing Features
-    - key: opinions_other.currently_missing_from_css
-      t: Was fehlt deiner Meinung nach derzeit in CSS?
-    - key: opinions_other.currently_missing_from_css.description
-      t: Wähle für jede Übereinstimmung die Funktion aus, die du heute am liebsten in CSS verwenden möchtest.
-    - key: opinions_other.currently_missing_from_css.others
-      t: Andere fehlende Funktionen
-    - key: opinions_others.currently_missing_from_css.others.note
-      t: >
-          Diese Ergebnisse wurden bearbeitet, basierend auf einem Freitextfeld.
-          Um alle Ergebnisse zu sehen, schaue auf [whatsmissingfromcss.com](http://whatsmissingfromcss.com/).
-
-    - key: opinions.sum_up_one_word_css
-      t: CSS in einem Wort
-    - key: opinions.sum_up_one_word_css.description
-      t: Wie würdest Du Deine Meinung über CSS in einem Wort zusammenfassen?
-
-    - key: happiness.state_of_the_web
-      t: Wie zufrieden bist Du allgemein mit den Webtechnologien?
-
-    - key: happiness.state_of_css
-      t: Wie zufrieden bist Du allgemein mit CSS?
+  - key: sections.interactions.title
+    t: Interaktionen
+  - key: sections.interactions.description
+    t: Kontrolliere wie der Nutzer mit der Seite interagiert.
+
+  - key: sections.typography.title
+    t: Typographie
+  - key: sections.typography.description
+    t: Einstellungen und Layout von Text.
+
+  - key: sections.animations_transforms.title
+    t: Animationen & Transformationen
+  - key: sections.animations_transforms.description
+    t: Animiere und transformiere Elemente.
+
+  - key: sections.accessibility.title
+    t: Accessibility
+  - key: sections.accessibility.description
+    t: Accessibility Features und Techniken.
+
+  - key: sections.media_queries.title
+    t: Media Queries
+  - key: sections.media_queries.description
+    t: Möglichkeiten die Seite an Geräte und Präferenzen von Nutzern anzupassen.
+
+  - key: sections.other_features.title
+    t: Andere Features
+  - key: sections.other_features.description
+    t: Andere CSS-Features.
+
+  - key: sections.units_selectors.title
+    t: Einheiten und Selektoren
+  - key: sections.units_selectors.description
+    t: Teste Dein Wissen zu CSS Einheiten und Selektoren.
+
+  - key: sections.pre_post_processors.title
+    t: Pre-/Post-processors
+  - key: sections.pre_post_processors.description
+    t: Werkzeuge, die CSS erweitern.
+
+  - key: sections.pre_post_processors_others.title
+    t: Andere Pre-/Post-Prozessoren
+
+  - key: sections.css_frameworks.title
+    t: CSS Frameworks
+  - key: sections.css_frameworks.description
+    t: Bibliotheken, die Dir vordefinierte Komponenten und Styles liefern.
+
+  - key: sections.css_frameworks_others.title
+    t: Andere CSS-Frameworks
+
+  - key: sections.css_methodologies.title
+    t: CSS Methoden
+  - key: sections.css_methodologies.description
+    t: Kodifizierte Optionen wie sauberes CSS geschrieben wird.
+
+  - key: sections.css_methodologies_others.title
+    t: Andere CSS-Methoden
+
+  - key: sections.css_in_js.title
+    t: CSS-in-JS
+  - key: sections.css_in_js.description
+    t: Bibliotheken, die bei der Integration von CSS nach JavaScript helfen.
+
+  - key: sections.css_in_js_others.title
+    t: Andere CSS-in-JS Bibliotheken
+
+  - key: sections.tools_others.title
+    t: Andere Werkzeuge
+  - key: sections.tools_others.description
+    t: Andere CSS-Werkzeuge
+
+  - key: sections.environments.title
+    t: Umgebungen
+  - key: sections.environments.description
+    t: Für welche Umgebungen schreibst Du CSS?
+
+  ###########################################################################
+  # Options
+  ###########################################################################
+
+  # CSS for print
+  - key: options.css_for_print.0
+    t: Ich schreibe fast nie Print Styles.
+  - key: options.css_for_print.0.short # TODO
+    t: Nie
+
+  - key: options.css_for_print.1
+    t: Ich schreibe gelegentlich Print Styles.
+  - key: options.css_for_print.1.short # TODO
+    t: Gelegentlich
+
+  - key: options.css_for_print.2
+    t: Ich schreibe Print Styles üblicherweise als Teil meiner Projekte.
+  - key: options.css_for_print.2.short # TODO
+    t: Oft
+
+  - key: options.css_for_print.3
+    t: Ich schreibe hauptsächlich Print Styles.
+  - key: options.css_for_print.3.short # TODO
+    t: Hauptsächlich
+
+  # CSS for email
+  - key: options.css_for_email.0
+    t: Ich schreibe fast nie CSS für E-Mail Clients.
+  - key: options.css_for_email.0.short # TODO
+    t: Nie
+
+  - key: options.css_for_email.1
+    t: Ich schreibe gelegentlich CSS für E-Mail Clients.
+  - key: options.css_for_email.1.short # TODO
+    t: Gelegentlich
+
+  - key: options.css_for_email.2
+    t: Ich schreibe CSS für E-Mail Clients üblicherweise als Teil meiner Projekte.
+  - key: options.css_for_email.2.short # TODO
+    t: Oft
+
+  - key: options.css_for_email.3
+    t: Ich schreibe CSS hauptsächlich für E-Mail Clients.
+  - key: options.css_for_email.3.short # TODO
+    t: Hauptsächlich
+
+  # CSS pain points
+  - key: options.css_pain_points.browser_interoperability
+    t: Browser Kompatibilität
+  - key: options.css_pain_points.browser_interoperability.description
+    t: Unterschiede zwischen Chrome, Safari, Firefox usw.
+  - key: options.css_pain_points.interactions
+    t: Interaktionen
+  - key: options.css_pain_points.interactions.description
+    t: Antwort auf Nutzereingaben und andere Events (scrollen, hover usw.).
+  - key: options.css_pain_points.architecture
+    t: Architektur & Wartbarkeit
+  - key: options.css_pain_points.architecture.description
+    t: Dateimanagement, Dead Code Eliminierung, Refactoring usw.
+  - key: options.css_pain_points.layout_positioning
+    t: Layout & Positionierung
+  - key: options.css_pain_points.layout_positioning.description
+    t: Entwerfen von Layouts und sicherstellen, dass Elemente am gewünschten Platz sind.
+  - key: options.css_pain_points.scoping_specificity
+    t: Bereiche & Spezifität
+  - key: options.css_pain_points.scoping_specificity.description
+    t: Die Kaskade und das Überschreiben von Stilen usw.
+  - key: options.css_pain_points.responsive_design
+    t: Responsive Design
+  - key: options.css_pain_points.responsive_design.description
+    t: Adaptieren von Layouts und Gestaltungen für verschiedene Geräte.
+  - key: options.css_pain_points.form_elements_styling
+    t: Stile für Formularelemente
+  - key: options.css_pain_points.form_elements_styling.description
+    t: Anpassung des Aussehens und des Verhaltens von Formularen.
+  - key: options.css_pain_points.performance_issues
+    t: Performance Probleme
+  - key: options.css_pain_points.performance_issues.description
+    t: Umgang mit Scrolling, Animationen flüssiger machen usw.
+
+  # CSS usage
+  - key: options.what_do_you_use_css_for.marketing_sites
+    t: Marketingseiten & Landingpages
+  - key: options.what_do_you_use_css_for.design_systems
+    t: Design Systems
+  - key: options.what_do_you_use_css_for.blogs
+    t: Blogs oder andere textlastige Webseiten
+  - key: options.what_do_you_use_css_for.web_apps
+    t: Webapps
+  - key: options.what_do_you_use_css_for.mobile_apps
+    t: Mobile Apps
+  - key: options.what_do_you_use_css_for.css_art
+    t: CSS-Kunst & Illustrationen
+  - key: options.what_do_you_use_css_for.emails
+    t: Emails
+  - key: options.what_do_you_use_css_for.printed_documents
+    t: Gedruckte Dokumente
+
+  ###########################################################################
+  # Features
+  ###########################################################################
+
+  # layout
+
+  - key: features.grid
+    t: CSS Grid
+  - key: features.subgrid
+    t: Subgrid
+  - key: features.regions
+    t: CSS Regions
+  - key: features.flexbox
+    t: Flexbox
+  - key: features.multi_column
+    t: CSS Multi-Column
+  - key: features.writing_modes
+    t: CSS Writing Modes
+  - key: features.exclusions
+    t: CSS Exclusions
+  - key: features.position_sticky
+    t: '<code>position: sticky</code>'
+  - key: features.logical_properties
+    t: Logical Properties
+  - key: features.logical_properties.description
+    t: <code>margin-block-start</code>, <code>padding-inline-end</code> usw.
+  - key: features.aspect_ratio
+    t: <code>aspect-ratio</code>
+  - key: features.content_visibility
+    t: <code>content-visibility</code>
+  - key: features.flexbox_gap
+    t: Gap Property für flexbox
+  - key: features.break_rules
+    t: Break rules
+  - key: features.break_rules.description
+    t: <code>break-inside</code>, <code>break-before</code>, <code>break-after</code>
+  - key: features.at_container
+    t: Container Queries
+  - key: features.at_container.description
+    t: <code>@container</code> query
+
+  # shapes & graphics
+  - key: features.shapes
+    t: CSS Shapes
+  - key: features.object_fit
+    t: <code>object-fit</code>
+  - key: features.clip_path
+    t: <code>clip-path</code>
+  - key: features.masks
+    t: CSS Masks
+  - key: features.blend_modes
+    t: Blend Modes
+  - key: features.blend_modes.description
+    t: Die <code>mix-blend-mode</code> Eigenschaft
+  - key: features.filter_effects
+    t: CSS Filter Effects
+  - key: features.backdrop_filter
+    t: <code>backdrop-filter</code>
+
+  - key: features.intrinsic_sizing
+    t: Intrinsic Sizing
+  - key: features.intrinsic_sizing.description
+    t: <code>min-content</code>, <code>max-content</code>, <code>fit-content</code>
+  - key: features.repeating_linear_gradient
+    t: <code>repeating-linear-gradient()</code>
+  - key: features.conic_gradient
+    t: <code>conic-gradient()</code>
+  - key: features.color_function
+    t: <code>color()</code>
+
+  - key: features.accent_color
+    t: <code>accent-color</code>
+
+  # interactions
+  - key: features.scroll_snap
+    t: CSS Scroll Snap
+  - key: features.overscroll_behavior
+    t: <code>overscroll-behavior</code>
+  - key: features.overflow_anchor
+    t: <code>overflow-anchor</code>
+  - key: features.touch_action
+    t: <code>touch-action</code>
+  - key: features.pointer_events
+    t: <code>pointer-events</code>
+  - key: features.scroll_timeline
+    t: <code>scroll-timeline</code>
+
+  # typography
+  - key: features.web_fonts
+    t: Web Fonts (@font-face)
+  - key: features.variables_fonts
+    t: Variable Fonts
+  - key: features.line_breaking
+    t: Line breaking Properties
+  - key: features.line_breaking.description
+    t: <code>overflow-wrap</code>, <code>word-break</code>, <code>line-break</code>, <code>hyphens</code>
+  - key: features.font_variant
+    t: <code>font-variant-*</code>
+  - key: features.initial_letter
+    t: <code>initial-letter</code>
+  - key: features.font_variant_numeric
+    t: <code>font-variant-numeric</code>
+  - key: features.font_display
+    t: <code>font-display</code>
+  - key: features.line_clamp
+    t: <code>line-clamp</code>
+  - key: features.leading_trim
+    t: <code>leading-trim</code>
+  - key: features.direction
+    t: <code>direction</code>
+  - key: features.direction.description
+    t: Beinhaltet auch <code>dir</code>-HTML-Attribute.
+
+  # animations & transforms
+  - key: features.transitions
+    t: CSS Transitions
+  - key: features.transforms
+    t: CSS Transforms
+  - key: features.animations
+    t: CSS Animations
+  - key: features.perspective
+    t: <code>perspective</code>
+
+  # media queries/accessibility
+  - key: features.feature_support_queries
+    t: Feature Support Queries (<code>@supports</code>)
+  - key: features.prefers_reduced_motion
+    t: <code>prefers-reduced-motion</code>
+  - key: features.prefers_color_scheme
+    t: <code>prefers-color-scheme</code>
+  - key: features.color_gamut
+    t: <code>color-gamut</code>
+
+  - key: features.prefers_reduced_data
+    t: <code>prefers-reduced-data</code>
+  - key: features.tabindex
+    t: <code>tabindex</code>-HTML-Attribute
+  - key: features.tabindex.description
+    t: <code>&lt;div tabindex="0"&gt;</code>
+
+  - key: features.color_contrast
+    t: <code>color-contrast()</code>
+
+  - key: features.color_scheme
+    t: <code>color-scheme</code>
+
+  - key: features.aria_attributes
+    t: ARIA-HTML-Attribute
+  - key: features.aria_attributes.description
+    t: <code>&lt;role&gt;</code>, <code>&lt;aria-label&gt;</code>, etc.
+
+  # other features
+  - key: features.variables
+    t: CSS Variables (Custom Properties)
+  - key: features.containment
+    t: CSS Containment
+  - key: features.will_change
+    t: <code>will-change</code>
+  - key: features.calc
+    t: <code>calc()</code>
+  - key: features.houdini
+    t: Houdini
+  - key: features.comparison_functions
+    t: CSS Comparison Functions
+  - key: features.comparison_functions.description
+    t: <code>min()</code>, <code>max()</code> und <code>clamp()</code>
+
+  - key: features.at_property
+    t: Houdini Custom Properties
+  - key: features.at_property.description
+    t: <code>@property</code>
+  - key: features.at_layer
+    t: <code>@layer</code>
+  - key: features.content_visibility
+    t: <code>content-visibility</code>
+  - key: features.marker
+    t: <code>::marker</code> pseudo-element
+
+  # missing features
+  - key: features.nesting
+    t: Verschachtelung
+  - key: features.nesting.description
+    t: Die Möglichkeit, Stile in nativem CSS zu verschachteln.
+  - key: features.parent_selector
+    t: Parent Selector
+  - key: features.parent_selector.description
+    t: Die Möglichkeit, auf ein übergeordnetes Element basierend auf seinen untergeordneten Elementen abzuzielen.
+  - key: features.browser_support
+    t: Browser Support
+  - key: features.browser_support.description
+    t: Bessere Browser-Unterstützung für existierende Features.
+  - key: features.mixins
+    t: Mixins
+  - key: features.mixins.description
+    t: Definitionen dynamisch gruppieren und wiederverwenden.
+  - key: features.color_functions
+    t: Color Functions
+  - key: features.color_functions.description
+    t: Funktionen zum Manipulieren von Farbwerten.
+  - key: features.container_queries
+    t: Container Queries
+  - key: features.container_queries.description
+    t: In der Lage sein, Stile basierend auf den Dimensionen des übergeordneten Containers zu schreiben.
+  - key: features.scoping
+    t: Scoping
+  - key: features.scoping.description
+    t: Die Möglichkeit, genauer anzugeben, wo die Stile angewendet werden.
+  - key: features.subgrid
+    t: Subgrid
+  - key: features.subgrid.description
+    t: Verschachtelung von Subgrids auf tieferen Ebenen in einem übergeordneten Raster.
+
+  ###########################################################################
+  # Units & Selectors
+  ###########################################################################
+
+  - key: features_others.units
+    t: Einheiten
+  - key: features_others.units.description
+    t: Welche dieser CSS Einheiten hast Du genutzt?
+
+  - key: options.units.px
+    t: px
+  - key: options.units.pt
+    t: pt
+  - key: options.units.percent
+    t: '%'
+  - key: options.units.em
+    t: em
+  - key: options.units.rem
+    t: rem
+  - key: options.units.vh_vw
+    t: vh, vw
+  - key: options.units.vmin_vmax
+    t: vmin, vmax
+  - key: options.units.ch
+    t: ch
+  - key: options.units.ex
+    t: ex
+  - key: options.units.mm
+    t: mm
+  - key: options.units.cm
+    t: cm
+  - key: options.units.in
+    t: in
+
+  - key: features_others.pseudo_elements
+    t: Pseudoelemente
+  - key: features_others.pseudo_elements.description
+    t: Welche dieser CSS Pseudoelemente hast Du genutzt?
+
+  - key: options.pseudo_elements.before
+    t: '::before'
+  - key: options.pseudo_elements.after
+    t: '::after'
+  - key: options.pseudo_elements.first_line
+    t: '::first-line'
+  - key: options.pseudo_elements.first_letter
+    t: '::first-letter'
+  - key: options.pseudo_elements.selection
+    t: '::selection'
+  - key: options.pseudo_elements.placeholder
+    t: '::placeholder'
+  - key: options.pseudo_elements.marker
+    t: '::marker'
+  - key: options.pseudo_elements.backdrop
+    t: '::backdrop'
+
+  - key: features_others.combinators
+    t: Verkettungen
+  - key: features_others.combinators.description # TODO
+    t: Welche dieser kombinierten CSS-Selektoren hast du verwendet?
+
+  - key: options.combinators.descendant
+    t: div span (absteigend)
+  - key: options.combinators.child
+    t: div > span (Kind)
+  - key: options.combinators.next_sibling
+    t: div + div (nächste Geschwister)
+  - key: options.combinators.subsequent_sibling
+    t: div ~ div (nachfolgende Geschwister)
+
+  - key: features_others.tree_document_structure
+    t: Baum/ Dokumentstruktur
+  - key: features_others.tree_document_structure.description # TODO
+    t: Welche dieser strukturbezogenen CSS-Selektoren hast du verwendet?
+
+  - key: options.tree_document_structure.root
+    t: :root
+  - key: options.tree_document_structure.empty
+    t: :empty
+  - key: options.tree_document_structure.not
+    t: :not()
+  - key: options.tree_document_structure.nth_child
+    t: :nth-child()
+  - key: options.tree_document_structure.nth_last_child
+    t: :nth-last-child()
+  - key: options.tree_document_structure.first_child
+    t: :first-child
+  - key: options.tree_document_structure.last_child
+    t: :last-child
+  - key: options.tree_document_structure.only_child
+    t: :only-child
+  - key: options.tree_document_structure.nth_of_type
+    t: :nth-of-type()
+  - key: options.tree_document_structure.nth_last_of_type
+    t: :nth-last-of-type()
+  - key: options.tree_document_structure.first_of_type
+    t: :first-of-type
+  - key: options.tree_document_structure.last_of_type
+    t: :last-of-type
+  - key: options.tree_document_structure.only_of_type
+    t: :only-of-type
+  - key: options.tree_document_structure.lang
+    t: :lang()
+  - key: options.tree_document_structure.is
+    t: :is()
+  - key: options.tree_document_structure.where
+    t: :where()
+  - key: options.tree_document_structure.has
+    t: :has()
+
+  - key: features_others.attributes
+    t: Attribute
+  - key: features_others.attributes.description # TODO
+    t: Welche dieser CSS-Attributselektoren hast du verwendet?
+
+  - key: options.attributes.presence
+    t: div[foo] (Vorhandensein)
+  - key: options.attributes.equality
+    t: div[foo="bar"] (Gleichwertigkeit)
+  - key: options.attributes.starts_with
+    t: div[foo^="bar"] (Beginnt mit)
+  - key: options.attributes.ends_with
+    t: div[foo$="bar"] (Endet mit)
+  - key: options.attributes.contains_word
+    t: div[foo~="bar"] (Beinhaltet Wort)
+  - key: options.attributes.contains_substring
+    t: div[foo*="bar"] (Beinhaltet Zeichen)
+
+  - key: features_others.links_urls
+    t: Links/URLs
+  - key: features_others.links_urls.description # TODO
+    t: Welche dieser Link- und URL-bezogenen CSS-Selektoren hast du verwendet?
+
+  - key: options.links_urls.any_link
+    t: :any-link
+  - key: options.links_urls.link_visited
+    t: :link und :visited
+  - key: options.links_urls.local_link
+    t: :local-link
+  - key: options.links_urls.target
+    t: :target
+
+  - key: features_others.interaction
+    t: Interaktion
+  - key: features_others.interaction.description # TODO
+    t: Welche dieser CSS-Selektoren für Interaktionen hast du verwendet?
+
+  - key: options.interaction.hover
+    t: :hover
+  - key: options.interaction.active
+    t: :active
+  - key: options.interaction.focus
+    t: :focus
+  - key: options.interaction.focus_within
+    t: :focus-within
+  - key: options.interaction.focus_visible
+    t: :focus-visible
+
+  - key: features_others.form_controls
+    t: Formularfelder
+  - key: features_others.form_controls.description # TODO
+    t: Welche dieser formularbezogenen CSS-Selektoren hast du verwendet?
+
+  - key: options.form_controls.enabled_disabled
+    t: :enabled und :disabled
+  - key: options.form_controls.read_only_write
+    t: :read-only und :read-write
+  - key: options.form_controls.placeholder_shown
+    t: :placeholder-shown
+  - key: options.form_controls.default
+    t: :default
+  - key: options.form_controls.checked
+    t: :checked
+  - key: options.form_controls.indeterminate
+    t: :indeterminate
+  - key: options.form_controls.valid_invalid
+    t: :valid und :invalid
+  - key: options.form_controls.user_invalid
+    t: :user-invalid
+  - key: options.form_controls.in_out_range
+    t: :in-range und :out-of-range
+  - key: options.form_controls.required_optional
+    t: :required und :optional
+
+  ###########################################################################
+  # Environments
+  ###########################################################################
+
+  - key: environments.browsers
+    t: Browser
+  - key: environments.browsers.description
+    t: Welchen Browser nutzt du zum Testen?
+
+  - key: environments.form_factors
+    t: Formfaktoren
+  - key: environments.form_factors.description
+    t: Mit welchen Formfaktoren testest du?
+
+  - key: environments.accessibility_features
+    t: Barrierefreiheitsfunktionen
+  - key: environments.accessibility_features.description
+    t: Welche Barrierefreiheitsfunktionen implementierst du normalerweise?
+  - key: environments.accessibility_features.others
+    t: Andere Barrierefreiheitsfunktionen
+  - key: environments.accessibility_features.others
+    t: Andere Barrierefreiheitsfunktionen, die du normalerweise implementierst.
+  - key: environments.what_do_you_use_css_for.others
+    t: Andere Projektarten
+  - key: environments.css_for_print
+    t: CSS für Print
+  - key: environments.css_for_print.description
+    t: Schreibst du Styles für Print?
+
+  - key: environments.css_for_email
+    t: CSS für E-Mail Clients
+  - key: environments.css_for_email.description
+    t: Schreibst Du CSS für E-Mail Clients?
+
+  - key: charts.axis_legends.css_for_print
+    t: Frequenz
+  - key: charts.axis_legends.css_for_email
+    t: Frequenz
+
+  - key: tools_others.tool_evaluation
+    t: Bibliotheksbewertung
+  - key: tools_others.tool_evaluation.description
+    t: Wähle für jede Übereinstimmung den Faktor aus, den du bei der Bewertung einer neuen Bibliothek priorisierst.
+
+  ###########################################################################
+  # Opinions
+  ###########################################################################
+
+  - key: opinions.css_easy_to_learn
+    t: CSS ist leicht zu lernen.
+  - key: opinions.css_easy_to_learn.title # TODO
+    t: Lernkurve
+
+  - key: opinions.css_evolving_slowly
+    t: CSS entwickelt sich zu langsam.
+  - key: opinions.css_evolving_slowly.title # TODO
+    t: Veränderungsrate
+
+  - key: opinions.utility_classes_to_be_avoided
+    t: Werkzeugklassen (nicht-semantische z.B. .center, .large-text, usw.) sollten vermieden werden.
+  - key: opinions.utility_classes_to_be_avoided.title # TODO
+    t: Non-Semantic Classes
+
+  - key: opinions.selector_nesting_to_be_avoided
+    t: Verschachteln von Selektoren (.foo .bar ul li {...}) sollte vermieden werden.
+  - key: opinions.selector_nesting_to_be_avoided.title # TODO
+    t: Selector Verschachtelung
+
+  - key: opinions.css_is_programming_language
+    t: CSS ist eine Programmiersprache.
+  - key: opinions.css_is_programming_language.title # TODO
+    t: Programmiersprache
+
+  - key: opinions.enjoy_writing_css
+    t: Ich genieße es CSS zu schreiben.
+  - key: opinions.enjoy_writing_css.title # TODO
+    t: Freude
+
+  # Browser interoperability question
+  - key: opinions.browser_interoperability_features
+    t: Browser-Inkompatibilitäten
+  - key: opinions.browser_interoperability_features.description
+    t: >
+      Gibt es CSS-Funktionen, die du aufgrund von Unterschieden
+      zwischen den Browsern nicht verwenden kannst?
+
+  # Pain Points
+  - key: opinions.css_pain_points
+    t: CSS Pain Points
+  - key: opinions.css_pain_points.description
+    t: Wähle für jede Übereinstimmung den Aspekt von CSS aus, mit dem du am meisten zu kämpfen hast.
+
+  - key: opinions_other.css_pain_points.others
+    t: Andere CSS Pain Points
+
+  # Missing Features
+  - key: opinions_other.currently_missing_from_css
+    t: Was fehlt deiner Meinung nach derzeit in CSS?
+  - key: opinions_other.currently_missing_from_css.description
+    t: Wähle für jede Übereinstimmung die Funktion aus, die du heute am liebsten in CSS verwenden möchtest.
+  - key: opinions_other.currently_missing_from_css.others
+    t: Andere fehlende Funktionen
+  - key: opinions_others.currently_missing_from_css.others.note
+    t: >
+      Diese Ergebnisse wurden bearbeitet, basierend auf einem Freitextfeld.
+      Um alle Ergebnisse zu sehen, schaue auf [whatsmissingfromcss.com](http://whatsmissingfromcss.com/).
+
+  - key: opinions.sum_up_one_word_css
+    t: CSS in einem Wort
+  - key: opinions.sum_up_one_word_css.description
+    t: Wie würdest Du Deine Meinung über CSS in einem Wort zusammenfassen?
+
+  - key: happiness.state_of_the_web
+    t: Wie zufrieden bist Du allgemein mit den Webtechnologien?
+
+  - key: happiness.state_of_css
+    t: Wie zufrieden bist Du allgemein mit CSS?
+
+  ###########################################################################
+  # Resources
+  ###########################################################################
+
+  # First steps
+  - key: resources.first_steps
+    t: Erste Schritte mit CSS
+  - key: resources.first_steps.description
+    t: Wie hast Du zu Beginn deiner Tätigkeit CSS gelernt?
+  - key: resources.first_steps.books
+    t: Bücher
+  - key: resources.first_steps.videos
+    t: Videos & Screencasts
+  - key: resources.first_steps.courses_free
+    t: Onlinekurse (kostenlos)
+  - key: resources.first_steps.courses_paid
+    t: Onlinekurse (bezahlt)
+  - key: resources.first_steps.school
+    t: Schule & höhere Bildung
+  - key: resources.first_steps.podcasts
+    t: Podcasts
+  - key: resources.first_steps.bootcamp
+    t: Bootcamps
+  - key: resources.first_steps.on_the_job
+    t: Ausbildung am Arbeitsplatz
+  - key: resources.first_steps.mentoring
+    t: Mentoring
+  - key: resources.first_steps.self_directed
+    t: Selbstgesteuertes Lernen (Google, Stack Overflow, usw.)
+  - key: resources.first_steps.others
+    t: Andere erste Lernmethoden
+  - key: resources.first_steps.others.description
+    t: Andere Antworten (Freifeld).


### PR DESCRIPTION
This PR adds some missing translations and fixes a typo

- Typo on Page 10 "Andere Werkzeuge", the tooltip on "Creator & Team": _Wird es von einem bekannten, erfahrenen und gut ausgestatteten **Tam** entwickelt?_ --> should be **_Team_**
- Missing translation on page 11 for the section "What do you mainly use CSS for?"
- Missing translation on page 12 for the section "First Steps With CSS" and "Other First Learning Methods"
- Missing translation on page 14 for the section "Higher Education Degree"

Haven't checked it with a local build, cause I don't know how..

Referenced [issue](https://github.com/StateOfJS/StateOfJS-Vulcan/issues/105)

 